### PR TITLE
Allow passing `github` in `extra_context`

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -5,7 +5,7 @@ uv lock && git init && git add . \
     && git commit --message '{{ cookiecutter.description }}' \
                   --message 'Bootstrapped from https://github.com/r73m/cookiecutter-python-app'
 
-{% if cookiecutter.github %}
+{% if cookiecutter.github in [True, 'y'] %}
 gh repo create --private --source . --push \
   --description '{{ cookiecutter.description }}'
 gh repo edit \


### PR DESCRIPTION
[`cookiecutter` command](https://cookiecutter.readthedocs.io/en/stable/cli_options.html) allows setting template parameters from [`extra_context`](https://cookiecutter.readthedocs.io/en/stable/advanced/injecting_context.html), i.e. a sequence of whitespace-separated key-value pairs specified as a part of the command line. I expected that values passed this way are parsed to theirs most specific types (*`int`, `bool`, etc*), but turned out [they are not](https://github.com/cookiecutter/cookiecutter/blob/80dc10b3a8a434b9b05fb4a51214ac6ba7df1b3e/cookiecutter/cli.py#L59). As a result `github` is tested according to [Python truth](https://docs.python.org/3/library/stdtypes.html#truth-value-testing), meaning that all, `github=False`, `github=false` and `github=n` are `True` and a repo is created. When set from the prompt everything works as expected.
This change allows to treat `github=y` as `True` as well. The single-letter format was chosen to match the prompt input.